### PR TITLE
remove hosp normal time point analysis

### DIFF
--- a/analysis/model/01_cox_pipeline.R
+++ b/analysis/model/01_cox_pipeline.R
@@ -74,6 +74,12 @@ analyses_to_run <- rbind(analyses_to_run, analyses_to_run_normal_timepoint)
 analyses_to_run$cohort <- cohort
 rm(analyses_to_run_normal_timepoint)
 
+#Remove VTE and PE hospitalied analysis with normal timepoints as this analysis does not run
+if(event_name %in% c("vte","pe")){
+  analyses_to_run <- analyses_to_run %>% filter(subgroup != "covid_pheno_hospitalised" | reduced_timepoint != "normal")
+  
+}
+
 # Source remainder of relevant files --------------------------------------------------------
 
 source(file.path(scripts_dir,paste0("03_01_cox_subgrouping.R"))) # Model specification


### PR DESCRIPTION
For VTE and PE the hospitalised analysis with normal timepoints does not run - remove this from the analyses_to_run df so it does not run