### PR TITLE
Extra analysis split first month

### DIFF
--- a/analysis/descriptives/days_covid19_to_hospitalisation.R
+++ b/analysis/descriptives/days_covid19_to_hospitalisation.R
@@ -1,0 +1,35 @@
+##################################################################################
+# 
+# Description: This script reads in the input data from stage 1 and provides
+#              the distribution of days from COVID-19 infection to hospitalisation
+#              for those considered as hospitalised COVID.
+#
+# Input: output/input_stage1.rds
+# Output: output/review/descriptives/days_COVID19_to_hospitalisation_pre_vaccination.csv"
+#
+##################################################################################
+
+library(readr)
+library(tidyverse)
+
+
+cohort_name <- "pre_vaccination"
+
+# Load relevant data
+input <- read_rds(paste0("output/input_stage1.rds"))
+
+# Get number of days between Covid diagnosis and hospital admission for hospitalised Covid cases
+input <- input %>%
+  mutate(days_Covid19_to_hospitalisation = 
+           ifelse(sub_cat_covid19_hospital == "hospitalised", input$sub_date_covid19_hospital - input$exp_date_covid19_confirmed, NA)
+  )
+table <- input %>% dplyr::count(days_Covid19_to_hospitalisation)
+
+# Add in suppression for counts <=5
+table_for_disclosure <- table %>%
+  mutate(n_people = 
+           ifelse(n >5, n, "[Redacted]")
+  ) %>%
+  select(days_Covid19_to_hospitalisation,n_people)
+
+write.csv(table_for_disclosure, file=paste0("output/review/descriptives/days_COVID19_to_hospitalisation_",cohort_name, ".csv"), row.names = F)

--- a/analysis/model/01_cox_pipeline.R
+++ b/analysis/model/01_cox_pipeline.R
@@ -79,12 +79,16 @@ rm(analyses_to_run_normal_timepoint)
 analyses_to_run <- analyses_to_run %>% filter((subgroup != "covid_pheno_hospitalised" | reduced_timepoint != "normal")
                                               & subgroup_cat != "aer")
 
-# Add day zero analyses
+# Add day zero analyses and first month split analyses
 day_zero_analyses <- analyses_to_run %>% filter(subgroup %in% c("main","covid_pheno_non_hospitalised"))
 day_zero_analyses$reduced_timepoint <- paste0("day_zero_",day_zero_analyses$reduced_timepoint)
-analyses_to_run <- rbind(analyses_to_run, day_zero_analyses)
-rm(day_zero_analyses)
 
+month1_split_analyses <- analyses_to_run %>% filter(subgroup %in% c("main","covid_pheno_non_hospitalised"))
+month1_split_analyses$reduced_timepoint <- paste0("month1_split_",month1_split_analyses$reduced_timepoint)
+
+analyses_to_run <- rbind(analyses_to_run, day_zero_analyses, month1_split_analyses)
+rm(day_zero_analyses)
+rm(month1_split_analyses)
 # Source remainder of relevant files --------------------------------------------------------
 
 source(file.path(scripts_dir,paste0("03_01_cox_subgrouping.R"))) # Model specification
@@ -102,10 +106,11 @@ if(nrow(analyses_to_run>0)){
              input,covar_names,
              cuts_days_since_expo,cuts_days_since_expo_reduced,
              cuts_days_since_expo_day_zero,cuts_days_since_expo_reduced_day_zero,
+             cuts_days_since_expo_month1_split,cuts_days_since_expo_reduced_month1_split,
              mdl))
 }
 
-#Save csv of anlayses not run
+#Save csv of analyses not run
 write.csv(analyses_not_run, paste0(output_dir,"/analyses_not_run_" , event_name ,"_",cohort,".csv"), row.names = T)
 
 if(nrow(analyses_to_run)==0){

--- a/analysis/model/02_02_cox_load_data.R
+++ b/analysis/model/02_02_cox_load_data.R
@@ -54,15 +54,19 @@ agelabels_strata <- c("18_39", "40_59", "60_79", "80_110")
 #a reduced number of time periods is used (need 197 instead of 196 as time periods are split using [ , ) 
 
 if(grepl("extended_follow_up",event_name)){
-  cuts_days_since_expo <- c(7, 14, 28, 56, 84, 197,365,714) 
-  cuts_days_since_expo_reduced <- c(28,197,365,714)
-  cuts_days_since_expo_day_zero <- c(1,7, 14, 28, 56, 84, 197,365,714) 
-  cuts_days_since_expo_reduced_day_zero <- c(1,28,197,365,714)
+  cuts_days_since_expo <- c(7, 14, 28, 56, 84, 197, 365, 714) 
+  cuts_days_since_expo_reduced <- c(28, 197, 365, 714)
+  cuts_days_since_expo_day_zero <- c(1, 7, 14, 28, 56, 84, 197, 365, 714) 
+  cuts_days_since_expo_reduced_day_zero <- c(1, 28, 197, 365, 714)
+  cuts_days_since_expo_month1_split <- c(1, 7, 14, 21, 28, 56, 84, 197, 365, 714) 
+  cuts_days_since_expo_reduced_month1_split <- c(1, 7, 14, 21, 28, 197, 365, 714)
 }else{
-  cuts_days_since_expo <- c(7, 14, 28, 56, 84, 197,535) 
-  cuts_days_since_expo_reduced <- c(28,197,535)
-  cuts_days_since_expo_day_zero <- c(1,7, 14, 28, 56, 84, 197,535) 
-  cuts_days_since_expo_reduced_day_zero <- c(1,28,197,535)
+  cuts_days_since_expo <- c(7, 14, 28, 56, 84, 197, 535) 
+  cuts_days_since_expo_reduced <- c(28, 197, 535)
+  cuts_days_since_expo_day_zero <- c(1, 7, 14, 28, 56, 84, 197, 535) 
+  cuts_days_since_expo_reduced_day_zero <- c(1, 28, 197, 535)
+  cuts_days_since_expo_month1_split <- c(1, 7, 14, 21, 28, 56, 84, 197, 535) 
+  cuts_days_since_expo_reduced_month1_split <- c(1, 7, 14, 21, 28, 197, 535)
 }
 
 

--- a/analysis/model/03_01_cox_subgrouping.R
+++ b/analysis/model/03_01_cox_subgrouping.R
@@ -5,7 +5,7 @@
 ## =============================================================================
 source(file.path(scripts_dir,"04_01_(a)_cox_fit_model.R"))
 
-get_vacc_res <- function(event,subgroup,stratify_by_subgroup,stratify_by,time_point,input,covar_names,cuts_days_since_expo,cuts_days_since_expo_reduced,cuts_days_since_expo_day_zero,cuts_days_since_expo_reduced_day_zero,uts_days_since_expo_month1_split,cuts_days_since_expo_reduced_month1_split,mdl){
+get_vacc_res <- function(event,subgroup,stratify_by_subgroup,stratify_by,time_point,input,covar_names,cuts_days_since_expo,cuts_days_since_expo_reduced,cuts_days_since_expo_day_zero,cuts_days_since_expo_reduced_day_zero,cuts_days_since_expo_month1_split,cuts_days_since_expo_reduced_month1_split,mdl){
   print(paste0("Working on subgroup: ", subgroup))
   print(paste0("Using ",time_point," time point"))
   

--- a/analysis/model/03_01_cox_subgrouping.R
+++ b/analysis/model/03_01_cox_subgrouping.R
@@ -5,7 +5,7 @@
 ## =============================================================================
 source(file.path(scripts_dir,"04_01_(a)_cox_fit_model.R"))
 
-get_vacc_res <- function(event,subgroup,stratify_by_subgroup,stratify_by,time_point,input,covar_names,cuts_days_since_expo,cuts_days_since_expo_reduced,cuts_days_since_expo_day_zero,cuts_days_since_expo_reduced_day_zero,mdl){
+get_vacc_res <- function(event,subgroup,stratify_by_subgroup,stratify_by,time_point,input,covar_names,cuts_days_since_expo,cuts_days_since_expo_reduced,cuts_days_since_expo_day_zero,cuts_days_since_expo_reduced_day_zero,uts_days_since_expo_month1_split,cuts_days_since_expo_reduced_month1_split,mdl){
   print(paste0("Working on subgroup: ", subgroup))
   print(paste0("Using ",time_point," time point"))
   
@@ -107,8 +107,11 @@ get_vacc_res <- function(event,subgroup,stratify_by_subgroup,stratify_by,time_po
     res_vacc <- fit_model_reducedcovariates(event,subgroup,stratify_by_subgroup,stratify_by,mdl, survival_data,input,cuts_days_since_expo=cuts_days_since_expo_reduced_day_zero,covar_names,time_point,total_covid_cases)
   }else if(time_point == "day_zero_normal"){
     res_vacc <- fit_model_reducedcovariates(event,subgroup,stratify_by_subgroup,stratify_by,mdl, survival_data,input,cuts_days_since_expo=cuts_days_since_expo_day_zero,covar_names,time_point,total_covid_cases)
+  }else if(time_point == "month1_split_reduced"){
+    res_vacc <- fit_model_reducedcovariates(event,subgroup,stratify_by_subgroup,stratify_by,mdl, survival_data,input,cuts_days_since_expo=cuts_days_since_expo_reduced_month1_split,covar_names,time_point)
+  }else if(time_point == "month1_split_normal"){
+    res_vacc <- fit_model_reducedcovariates(event,subgroup,stratify_by_subgroup,stratify_by,mdl, survival_data,input,cuts_days_since_expo=cuts_days_since_expo_month1_split,covar_names,time_point)
   }
-
   print(paste0("Finished working on subgroup: ", subgroup))
   return(res_vacc)
 }

--- a/analysis/model/07_combine_HRs_to_one_file.R
+++ b/analysis/model/07_combine_HRs_to_one_file.R
@@ -69,3 +69,26 @@ event_counts_day_zero <- rbind(event_counts_day_zero, tmp_hosp)
 
 write.csv(event_counts_day_zero,paste0(output_dir,"/R_event_count_day_zero_output_pre_vax.csv") , row.names=F)
 
+#Get event counts by time period for first month split analyses
+event_counts_df$events_total <- as.numeric(event_counts_df$events_total)
+event_counts_month1_split <- event_counts_df %>% filter(time_points == "month1_split_reduced"
+                                                        & event %in% c("ate_extended_follow_up", "vte_extended_follow_up",
+                                                                       "ate_primary_position_extended_follow_up", "vte_primary_position_extended_follow_up"))%>%
+  select(event,cohort,subgroup,time_points,expo_week,events_total)
+
+
+tmp_hosp <- event_counts_month1_split %>% filter(subgroup == "main") %>%
+  left_join(event_counts_month1_split %>% filter(subgroup == "covid_pheno_non_hospitalised") %>%
+              select(!subgroup)%>%
+              rename(events_total_non_hosp = events_total))
+
+tmp_hosp$events_total_hosp <- tmp_hosp$events_total - tmp_hosp$events_total_non_hosp
+tmp_hosp$events_total <- NULL
+tmp_hosp$events_total_non_hosp <- NULL
+
+tmp_hosp$subgroup <- "covid_pheno_hospitalised"
+tmp_hosp <- rename(tmp_hosp, events_total=events_total_hosp)
+
+event_counts_month1_split <- rbind(event_counts_month1_split, tmp_hosp)
+
+write.csv(event_counts_month1_split,paste0(output_dir,"/R_event_count_month1_split_output.csv") , row.names=F)

--- a/project.yaml
+++ b/project.yaml
@@ -138,6 +138,14 @@ actions:
       moderately_sensitive:
         histogram_data: output/review/descriptives/histogram_data_pre_vaccination_extended_follow_up.csv
 
+  days_covid19_to_hospitalisation:
+    run: r:latest analysis/descriptives/days_covid19_to_hospitalisation.R
+    needs:
+    - stage1_data_cleaning
+    outputs:
+      moderately_sensitive:
+        distribution: output/review/descriptives/days_COVID19_to_hospitalisation_pre_vaccination.csv
+
   ## Apply cox model for ami 
 
   Analysis_cox_ami:


### PR DESCRIPTION
Adding an extra analysis splitting the first month into multiple time periods. The analysis is integrated into the existing Cox actions similar to the day_zero analysis.
There is also an additional action to count days from Covid diagnosis to hospitalisation for those identified as Covid hospitalised.